### PR TITLE
Update TableConstants.js

### DIFF
--- a/lib/TableConstants.js
+++ b/lib/TableConstants.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-var keyMirror = require('react/lib/keymirror');
+var keyMirror = require('react/lib/keyMirror');
 
 exports['default'] = {
   DIRECTION: keyMirror({


### PR DESCRIPTION
keyMirror named with upper-cased letter 'M', that's why I have some problem on Linux